### PR TITLE
Add Conforma MintMaker Renovate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# renovate-config
-Inherited config for konflux-ci/mintmaker
+# Mintmaker Config for Conforma
+
+This repository contains an [inherited configuration](https://konflux-ci.dev/docs/mintmaker/user/#inherited-config) for [Konflux Mintmaker](https://github.com/konflux-ci/mintmaker). This configuration extends and overrides the [default Mintmaker configuration for Konflux](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json), and is shared among all the repositories in the Conforma organization.
+
+## About Mintmaker
+
+Mintmaker is a Konflux project that automates dependency checking and updating for components using [Renovate](https://docs.renovatebot.com/). It introduces the `DependencyUpdateCheck` custom resource to trigger dependency update processes across Konflux components on GitHub and GitLab platforms.
+
+## Contributing
+
+To modify this shared configuration, please create a pull request with your proposed changes. Consider the impact on all repositories that inherit from this configuration.

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Conforma organization inherited MintMaker (Renovate) configuration",
+  "extends": [
+    "config:recommended",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePresets": [
+    ":dependencyDashboard"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "timezone": "America/New_York",
+  "packageRules": [
+    {
+      "description": "Group major Go version updates with clear labeling",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go", "toolchain"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major_go_version_update",
+      "commitMessagePrefix": "🚨 Major: ",
+      "commitMessageAction": "Update Go"
+    },
+    {
+      "description": "Group major Go Docker image updates with clear labeling",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["golang", "go", "docker.io/library/golang"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major_go_version_update",
+      "commitMessagePrefix": "🚨 Major: ",
+      "commitMessageAction": "Update Go"
+    },
+    {
+      "description": "Disable minor version updates for v0 majors (unstable API)",
+      "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
+      "description": "Enable minor and patch Go version updates with grouping",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go", "toolchain"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "go_version_update",
+      "commitMessageAction": "Update Go"
+    },
+    {
+      "description": "Enable minor and patch Go Docker updates with grouping",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["docker.io/library/golang", "golang", "go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "go_version_update",
+      "commitMessageAction": "Update Go"
+    },
+    {
+      "description": "Group Go module updates (excluding Go version itself)",
+      "matchManagers": ["gomod"],
+      "excludePackageNames": ["go", "toolchain"],
+      "groupName": "go_module_updates",
+      "commitMessageAction": "Update Go dependencies"
+    },
+    {
+      "description": "Enable Tekton automerge for safe updates",
+      "matchManagers": ["tekton"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Group other Docker updates",
+      "matchManagers": ["dockerfile"],
+      "excludePackageNames": ["docker.io/library/golang", "golang", "go"],
+      "versioning": "semver",
+      "groupName": "docker_updates",
+      "commitMessageAction": "Update Docker images"
+    },
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchFiles": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
+      "automerge": true,
+      "groupName": "github_actions_updates",
+      "commitMessageAction": "Update GitHub Actions"
+    }
+  ],
+  "postUpdateOptions": ["gomodTidy"]
+}


### PR DESCRIPTION
Comprehensive dependency management for Go projects.

Main features:
- Groups Go version bumps from gomod and docker images in the same PR
- Keeps Go minor/patch PRs separated from major PRs. PRs for major Go version bumps are clearly labeled
- Groups all go modules bumps in the same PR
- Disables minor updates for unstable APIs (v0 minor bumps)
- Automerges Tekton patches and GitHub Actions

Assisted by: Cursor (powered by Claude 4 Sonnet)

Ref: https://issues.redhat.com/browse/EC-1329