### PR TITLE
Remove 'extends' section in config

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Conforma organization inherited MintMaker (Renovate) configuration",
-  "extends": [
-    "config:recommended",
-    ":gitSignOff",
-    ":disableDependencyDashboard"
-  ],
   "ignorePresets": [
     ":dependencyDashboard"
   ],


### PR DESCRIPTION
This section probably causes a loop in the merge of the inherited config with the default config. Removing it should solve the issue.

Ref: https://issues.redhat.com/browse/EC-1329